### PR TITLE
fix never ending timeout for xrv and calculate command timeout same w…

### DIFF
--- a/scripts/config_asa.py
+++ b/scripts/config_asa.py
@@ -362,7 +362,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -404,7 +404,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_asav.py
+++ b/scripts/config_asav.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -349,7 +349,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_csr1000v.py
+++ b/scripts/config_csr1000v.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -333,7 +333,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_docker.py
+++ b/scripts/config_docker.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
             docker_id = a
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -147,7 +147,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, docker_id))
     p.start()
 

--- a/scripts/config_mikrotik.py
+++ b/scripts/config_mikrotik.py
@@ -74,10 +74,12 @@ def config_get(handler):
             handler.expect(MTK_PROMPT, timeout = expctimeout)
             break
         except:
+            time.sleep(0.5)
             continue
 
     # Getting the config
     handler.send('/export\r\n')
+    time.sleep(0.5)
     try:
         handler.expect(MTK_PROMPT, timeout = longtimeout)
     except:
@@ -93,7 +95,7 @@ def config_get(handler):
 
     # Manipulating the config
     config = re.sub('\r', '', config, flags=re.DOTALL)                                      # Unix style
-    config = re.sub('/export', '\r', config, flags=re.DOTALL)                                      # Unix style
+    #config = re.sub('/export$', '\r', config, flags=re.DOTALL)                                      # Unix style
     config = re.sub('.*!! IOS XR Configuration', '!! IOS XR Configuration', config, flags=re.DOTALL)   # Header
     config = re.sub('no logging console' , '\n!\n' , config, flags=re.DOTALL) # suppress no login console
     config = re.sub('$.*', '\n!\nend\n', config, flags=re.DOTALL)                # Footer

--- a/scripts/config_mikrotik.py
+++ b/scripts/config_mikrotik.py
@@ -93,6 +93,7 @@ def config_get(handler):
 
     # Manipulating the config
     config = re.sub('\r', '', config, flags=re.DOTALL)                                      # Unix style
+    config = re.sub('/export', '\r', config, flags=re.DOTALL)                                      # Unix style
     config = re.sub('.*!! IOS XR Configuration', '!! IOS XR Configuration', config, flags=re.DOTALL)   # Header
     config = re.sub('no logging console' , '\n!\n' , config, flags=re.DOTALL) # suppress no login console
     config = re.sub('$.*', '\n!\nend\n', config, flags=re.DOTALL)                # Footer

--- a/scripts/config_mikrotik.py
+++ b/scripts/config_mikrotik.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+
+# scripts/config_xrv.py
+#
+# Import/Export script for vIOS.
+#
+# @author Andrea Dainese <andrea.dainese@gmail.com>
+# @copyright 2014-2016 Andrea Dainese
+# @license BSD-3-Clause https://github.com/dainok/unetlab/blob/master/LICENSE
+# @link http://www.unetlab.com/
+# @version 20160719
+
+import getopt, multiprocessing, os, pexpect, re, sys, time, platform
+from pexpect import popen_spawn
+
+username = 'admin'
+password = ''
+secret = 'cisco'
+conntimeout = 3     # Maximum time for console connection
+expctimeout = 3     # Maximum time for each short expect
+longtimeout = 30    # Maximum time for each long expect
+timeout = 60        # Maximum run time (conntimeout is included)
+ip = '127.0.0.1'
+
+def IsWindows():
+    return platform.system() == 'Windows'
+
+def handler_isalive(handler):
+    if IsWindows():
+        return True
+    else:
+        return handler.isalive()
+
+def pexpect_spawn(cmd):
+    if (IsWindows()):
+        return pexpect.popen_spawn.PopenSpawn(cmd)
+    else:
+        return pexpect.spawn(cmd)
+
+
+
+def node_login(handler):
+    # Send an empty line, and wait for the login prompt
+    i = -1
+    while i == -1:
+        try:
+            handler.sendline('\r\n')
+            i = handler.expect([
+                '.*Login:'], timeout = 5)
+        except:
+            i = -1
+
+    if i == 0:
+        # Need to send username and password
+        handler.sendline(username)
+        try:
+            handler.expect('Password:', timeout = expctimeout)
+        except:
+            print('ERROR: error waiting for "Password:" prompt.')
+            node_quit(handler)
+            return False
+
+        handler.sendline(password)
+        try:
+            handler.expect(']\s>', timeout = expctimeout)
+        except:
+            print('ERROR: error waiting for "] >" prompt.')
+            node_quit(handler)
+            return False
+        return True
+    else:
+        # Unexpected output
+        node_quit(handler)
+        return False
+
+def node_firstlogin(handler):
+    # Send an empty line, and wait for the login prompt
+    i = -1
+    while i == -1:
+        try:
+            handler.sendline('\r\n')
+            i = handler.expect('Username:', timeout = 5)
+        except:
+            i = -1
+
+    if i == 0:
+        # Need to send username and password
+        handler.sendline(username)
+        try:
+            handler.expect('Password:', timeout = expctimeout)
+        except:
+            print('ERROR: error waiting for "Password:" prompt.')
+            node_quit(handler)
+            return False
+
+        handler.sendline(password)
+        try:
+            handler.expect('[^)]#', timeout = expctimeout)
+        except:
+            print('ERROR: error waiting for "#" prompt.')
+            node_quit(handler)
+            return False
+        return True
+    else:
+        # Unexpected output
+        node_quit(handler)
+        return False
+
+
+
+def node_quit(handler):    
+    if handler_isalive(handler) == True:
+        handler.sendline('quit\n')
+    handler.close()
+
+def config_get(handler):
+    # Clearing all "expect" buffer
+    while True:
+        try:
+            handler.expect('#', timeout = 0.1)
+        except:
+            break
+
+    # Disable paging
+    handler.sendline('terminal length 0')
+    try:
+        handler.expect('#', timeout = expctimeout)
+    except:
+        print('ERROR: error waiting for "#" prompt.')
+        node_quit(handler)
+        return False
+
+    handler.sendline('configure terminal')
+    try:
+        handler.expect('#', timeout = expctimeout)
+    except:
+        print('ERROR: error waiting for "#" prompt.')
+        node_quit(handler)
+        return False
+
+    handler.sendline('no logging console')
+    try:
+        handler.expect('#', timeout = expctimeout)
+    except:
+        print('ERROR: error waiting for "#" prompt.')
+        node_quit(handler)
+        return False
+
+    handler.sendline('commit')
+    try:
+        handler.expect('#', timeout = expctimeout)
+    except:
+        print('ERROR: error waiting for "#" prompt.')
+        node_quit(handler)
+        return False
+
+    handler.sendline('exit')
+    try:
+        handler.expect('#', timeout = expctimeout) 
+    except:
+        print('ERROR: error waiting for "#" prompt.')
+        node_quit(handler)
+        return False
+
+    # Getting the config
+    handler.sendline('show running-config')
+    try:
+        handler.expect('!\r\nend\r\n', timeout = longtimeout)
+    except:
+        print('ERROR: error waiting for "end" marker.')
+        node_quit(handler)
+        return False
+    config = handler.before.decode()
+
+    # Manipulating the config
+    config = re.sub('\r', '', config, flags=re.DOTALL)                                      # Unix style
+    config = re.sub('.*!! IOS XR Configuration', '!! IOS XR Configuration', config, flags=re.DOTALL)   # Header
+    config = re.sub('no logging console' , '\n!\n' , config, flags=re.DOTALL) # suppress no login console
+    config = re.sub('$.*', '\n!\nend\n', config, flags=re.DOTALL)                # Footer
+    return config
+
+def config_put(handler): 
+    while True:
+        try:
+           i = handler.expect('CVAC-4-CONFIG_DONE', timeout)
+        except:
+           return False
+        return True
+
+def usage():
+    print('Usage: %s <standard options>' %(sys.argv[0]));
+    print('Standard Options:');
+    print('-a <s>    *Action can be:')
+    print('           - get: get the startup-configuration and push it to a file')
+    print('           - put: put the file as startup-configuration')
+    print('-f <s>    *File');
+    print('-p <n>    *Console port');
+    print('-t <n>     Timeout (default = %i)' %(timeout));
+    print('* Mandatory option')
+
+def now():
+    # Return current UNIX time in milliseconds
+    return int(round(time.time() * 1000))
+
+def main(action, fiename, port):
+    try:
+        # Connect to the device
+        tmp = conntimeout
+        while (tmp > 0):
+            handler = pexpect_spawn('telnet %s %i' %(ip, port))
+            time.sleep(0.1)
+            tmp = tmp - 0.1
+            if handler_isalive(handler) == True:
+                break
+
+        if action == 'get':
+            if (handler_isalive(handler) != True):
+                print('ERROR: cannot connect to port "%i".' %(port))
+                node_quit(handler)
+                sys.exit(1)
+            rc = node_login(handler)
+            if rc != True:
+                print('ERROR: failed to login.')
+                node_quit(handler)
+                sys.exit(1)
+            config = config_get(handler)
+            if config in [False, None]:
+                print('ERROR: failed to retrieve config.')
+                node_quit(handler)
+                sys.exit(1)
+
+            try:
+                fd = open(filename, 'a')
+                fd.write(config)
+                fd.close()
+            except:
+                print('ERROR: cannot write config to file.')
+                node_quit(handler)
+                sys.exit(1)
+        elif action == 'put':
+            rc = config_put(handler)
+            if rc != True:
+                print('ERROR: failed to push config.')
+                node_quit(handler)
+                sys.exit(1)
+
+            # Remove lock file
+            lock = '%s/.lock' %(os.path.dirname(filename))
+
+            if os.path.exists(lock):
+                os.remove(lock)
+
+            # Mark as configured
+            configured = '%s/.configured' %(os.path.dirname(filename))
+            if not os.path.exists(configured):
+                open(configured, 'a').close()
+
+        node_quit(handler)
+        sys.exit(0)
+
+    except Exception as e:
+        print('ERROR: got an exception')
+        print(type(e))  # the exception instance
+        print(e.args)   # arguments stored in .args
+        print(e)        # __str__ allows args to be printed directly,
+        node_quit(handler)
+        return False
+
+if __name__ == "__main__":
+    action = None
+    filename = None
+    port = None
+
+    # Getting parameters from command line
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'a:p:t:f:i', ['action=', 'port=', 'timeout=', 'file=', 'address='])
+    except getopt.GetoptError as e:
+        usage()
+        sys.exit(3)
+
+    for o, a in opts:
+        if o in ('-a', '--action'):
+            action = a
+        elif o in ('-f', '--file'):
+            filename = a
+        elif o in ('-p', '--port'):
+            try:
+                port = int(a)
+            except:
+                port = -1
+        elif o in ('-t', '--timeout'):
+            try:
+                timeout = int(a)
+            except:
+                timeout = -1
+        elif o in ('-i', '--address'):
+            ip = a
+        else:
+            print('ERROR: invalid parameter.')
+
+    # Checking mandatory parameters
+    if action == None or port == None or filename == None:
+        usage()
+        print('ERROR: missing mandatory parameters.')
+        sys.exit(1)
+    if action not in ['get', 'put']:
+        usage()
+        print('ERROR: invalid action.')
+        sys.exit(1)
+    if timeout < 0:
+        usage()
+        print('ERROR: timeout must be 0 or higher.')
+        sys.exit(1)
+    if port < 0:
+        usage()
+        print('ERROR: port must be 32768 or higher.')
+        sys.exit(1)
+    if action == 'get' and os.path.exists(filename):
+        usage()
+        print('ERROR: destination file already exists.')
+        sys.exit(1)
+    if action == 'put' and not os.path.exists(filename):
+        usage()
+        print('ERROR: source file does not already exist.')
+        sys.exit(1)
+    if action == 'put':
+        try:
+            fd = open(filename, 'r')
+            config = fd.read()
+            fd.close()
+        except:
+            usage()
+            print('ERROR: cannot read from file.')
+            sys.exit(1)
+
+    if IsWindows():
+       r = main(action, filename, port)
+       if r != True:
+           sys.exit(127)
+    else:
+        # Backgrounding the script
+        end_before = now() + timeout * 1000
+        p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
+        p.start()
+
+        while (p.is_alive() and now() < end_before):
+            # Waiting for the child process to end
+            time.sleep(1)
+
+        if p.is_alive():
+            # Timeout occurred
+            print('ERROR: timeout occurred.')
+            p.terminate()
+            sys.exit(127)
+
+        if p.exitcode != 0:
+            sys.exit(127)
+
+    sys.exit(0)

--- a/scripts/config_pfsense.py
+++ b/scripts/config_pfsense.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -238,7 +238,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_titanium.py
+++ b/scripts/config_titanium.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -282,7 +282,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_veos.py
+++ b/scripts/config_veos.py
@@ -316,7 +316,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -358,7 +358,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_vios.py
+++ b/scripts/config_vios.py
@@ -290,7 +290,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_viosl2.py
+++ b/scripts/config_viosl2.py
@@ -290,7 +290,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_vmx.py
+++ b/scripts/config_vmx.py
@@ -326,7 +326,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -368,7 +368,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_vsrx.py
+++ b/scripts/config_vsrx.py
@@ -326,7 +326,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -368,7 +368,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_vsrxng.py
+++ b/scripts/config_vsrxng.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -313,7 +313,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(action, filename, port))
     p.start()
 

--- a/scripts/config_xrv.py
+++ b/scripts/config_xrv.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:

--- a/scripts/wrconf_dyn.py
+++ b/scripts/wrconf_dyn.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -265,7 +265,7 @@ if __name__ == "__main__":
         sys.exit(1)
     
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(port,))
     p.start()
 

--- a/scripts/wrconf_iol.py
+++ b/scripts/wrconf_iol.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
                 port = -1
         elif o in ('-t', '--timeout'):
             try:
-                timeout = int(a) * 1000
+                timeout = int(a)
             except:
                 timeout = -1
         else:
@@ -260,7 +260,7 @@ if __name__ == "__main__":
         sys.exit(1)
     
     # Backgrounding the script
-    end_before = now() + timeout
+    end_before = now() + timeout * 1000
     p = multiprocessing.Process(target=main, name="Main", args=(port,))
     p.start()
 


### PR DESCRIPTION
…ay in the all config scripts

As we get a timeout constant in each script defined as timeout=60 (line 21) and unetlab web application run the config scripts with -t 15 I suppose timeout should be declared in seconds. There was a double 1000 multiplication in config_xrv.py so the script had no way to exit via timeout.